### PR TITLE
Allow ordinal and categorical vars to be used in skip logic 

### DIFF
--- a/__tests__/predicate.test.js
+++ b/__tests__/predicate.test.js
@@ -86,6 +86,50 @@ describe('predicate', () => {
         predicate(operators.NOT_EXISTS)({ value: null })
       ).toBe(true);
     });
+
+    // True if all values are included
+    it('INCLUDES', () => {
+      const other = ['a', 'b', 'c'];
+      const value1 = ['a'];
+      const value2 = ['a', 'b'];
+      const value3 = ['c', 'd'];
+      const value4 = ['d'];
+
+      expect(
+        predicate(operators.INCLUDES)({ value: value1, other })
+      ).toBe(true);
+      expect(
+        predicate(operators.INCLUDES)({ value: value2, other })
+      ).toBe(true);
+      expect(
+        predicate(operators.INCLUDES)({ value: value3, other })
+      ).toBe(false);
+      expect(
+        predicate(operators.INCLUDES)({ value: value4, other })
+      ).toBe(false);
+    });
+
+    // True if all values are excluded
+    it('EXCLUDES', () => {
+      const other = ['a', 'b', 'c'];
+      const value1 = ['a'];
+      const value2 = ['a', 'b'];
+      const value3 = ['c', 'd'];
+      const value4 = ['d'];
+
+      expect(
+        predicate(operators.EXCLUDES)({ value: value1, other })
+      ).toBe(false);
+      expect(
+        predicate(operators.EXCLUDES)({ value: value2, other })
+      ).toBe(false);
+      expect(
+        predicate(operators.EXCLUDES)({ value: value3, other })
+      ).toBe(false);
+      expect(
+        predicate(operators.EXCLUDES)({ value: value4, other })
+      ).toBe(true);
+    });
   });
 
   describe('Count operators', () => {

--- a/predicate.js
+++ b/predicate.js
@@ -6,6 +6,8 @@ const {
 // operators list
 const operators = {
   EXACTLY: 'EXACTLY',
+  INCLUDES: 'INCLUDES',
+  EXCLUDES: 'EXCLUDES',
   EXISTS: 'EXISTS',
   NOT_EXISTS: 'NOT_EXISTS',
   NOT: 'NOT',
@@ -59,6 +61,10 @@ const predicate = operator =>
       case operators.NOT:
       case countOperators.COUNT_NOT:
         return !isEqual(value, other);
+      case operators.INCLUDES:
+        return other.includes(value);
+      case operators.EXCLUDES:
+        return !other.includes(value);
       case operators.EXISTS:
         return !isNull(value);
       case operators.NOT_EXISTS:

--- a/predicate.js
+++ b/predicate.js
@@ -61,10 +61,14 @@ const predicate = operator =>
       case operators.NOT:
       case countOperators.COUNT_NOT:
         return !isEqual(value, other);
-      case operators.INCLUDES:
-        return other.includes(value);
-      case operators.EXCLUDES:
-        return !other.includes(value);
+      case operators.INCLUDES: {
+        const difference = value.filter(x => !other.includes(x));
+        return difference.length === 0;
+      }
+      case operators.EXCLUDES: {
+        const difference = value.filter(x => other.includes(x));
+        return difference.length === 0;
+      }
       case operators.EXISTS:
         return !isNull(value);
       case operators.NOT_EXISTS:


### PR DESCRIPTION
> The network query lib should be updated to implement checking within the array values that these variable types are stored as

Categorical introduces 2 new rule types, INCLUDES and EXCLUDES:
```
    INCLUDES:
    [a, b, c] includes [a]         true
    [a, b, c] includes [a, b]      true
    [a, b, c] includes [c, d]      false
    [a, b, c] includes [d]         false

    EXCLUDES:
    [a, b, c] excludes [a]         false
    [a, b, c] excludes [a, b]      false
    [a, b, c] excludes [c, d]      false
    [a, b, c] excludes [d]         true
```

No change for ordinal, uses EXACTLY rule

Partially resolves: https://github.com/codaco/Architect/issues/483