### PR TITLE
add logic for initialised null variables to includes/excludes

### DIFF
--- a/__tests__/rules.test.js
+++ b/__tests__/rules.test.js
@@ -6,9 +6,9 @@ const generateNode = helpers.getNodeGenerator();
 const generateRuleConfig = helpers.generateRuleConfig;
 
 const nodes = [
-  generateNode({ name: 'William', age: 19 }),
-  generateNode({ name: 'Theodore', age: 18 }),
-  generateNode({ name: 'Rufus', age: 51 }),
+  generateNode({ name: 'William', age: 19, categoricalNull: null }),
+  generateNode({ name: 'Theodore', age: 18, categoricalNull: null }),
+  generateNode({ name: 'Rufus', age: 51, categoricalNull: null }),
   generateNode({ name: 'Phone Box' }, 'public_utility'),
 ];
 
@@ -31,12 +31,12 @@ describe('rules', () => {
 
   describe('alter rules', () => {
     describe('faulty rules', () => {
-      it('ignores missing numerical attribute (EXACTLY)', () => {
+      it('correctly handles missing attribute (EXACTLY)', () => {
         const ruleConfig = generateRuleConfig(
           'alter',
           {
             type: 'person',
-            attribute: 'missingAttribute',
+            attribute: 'missingVariable',
             operator: 'EXACTLY',
             value: 19,
           }
@@ -47,12 +47,12 @@ describe('rules', () => {
         expect(matches.length).toEqual(0);
       });
 
-      it('ignores missing numerical attribute (NOT)', () => {
+      it('correctly handles missing attribute (NOT)', () => {
         const ruleConfig = generateRuleConfig(
           'alter',
           {
             type: 'person',
-            attribute: 'missingAttribute',
+            attribute: 'missingVariable',
             operator: 'NOT',
             value: 19,
           }
@@ -63,12 +63,12 @@ describe('rules', () => {
         expect(matches.length).toEqual(3);
       });
 
-      it('ignores missing categorical attribute (INCLUDES)', () => {
+      it('correctly handles falsey categorical attribute (INCLUDES)', () => {
         const ruleConfig = generateRuleConfig(
           'alter',
           {
             type: 'person',
-            attribute: 'missingAttribute',
+            attribute: 'categoricalNull',
             operator: 'INCLUDES',
             value: [19],
           }
@@ -79,12 +79,12 @@ describe('rules', () => {
         expect(matches.length).toEqual(0);
       });
 
-      it('ignores missing categorical attribute (EXCLUDES)', () => {
+      it('correctly handles falsey categorical attribute (EXCLUDES)', () => {
         const ruleConfig = generateRuleConfig(
           'alter',
           {
             type: 'person',
-            attribute: 'missingAttribute',
+            attribute: 'categoricalNull',
             operator: 'EXCLUDES',
             value: [19],
           }

--- a/__tests__/rules.test.js
+++ b/__tests__/rules.test.js
@@ -30,6 +30,73 @@ describe('rules', () => {
 
 
   describe('alter rules', () => {
+    describe('faulty rules', () => {
+      it('ignores missing numerical attribute (EXACTLY)', () => {
+        const ruleConfig = generateRuleConfig(
+          'alter',
+          {
+            type: 'person',
+            attribute: 'missingAttribute',
+            operator: 'EXACTLY',
+            value: 19,
+          }
+        );
+
+        const rule = getRule(ruleConfig);
+        const matches = nodes.filter(rule);
+        expect(matches.length).toEqual(0);
+      });
+
+      it('ignores missing numerical attribute (NOT)', () => {
+        const ruleConfig = generateRuleConfig(
+          'alter',
+          {
+            type: 'person',
+            attribute: 'missingAttribute',
+            operator: 'NOT',
+            value: 19,
+          }
+        );
+
+        const rule = getRule(ruleConfig);
+        const matches = nodes.filter(rule);
+        expect(matches.length).toEqual(3);
+      });
+
+      it('ignores missing categorical attribute (INCLUDES)', () => {
+        const ruleConfig = generateRuleConfig(
+          'alter',
+          {
+            type: 'person',
+            attribute: 'missingAttribute',
+            operator: 'INCLUDES',
+            value: [19],
+          }
+        );
+
+        const rule = getRule(ruleConfig);
+        const matches = nodes.filter(rule);
+        expect(matches.length).toEqual(0);
+      });
+
+      it('ignores missing categorical attribute (EXCLUDES)', () => {
+        const ruleConfig = generateRuleConfig(
+          'alter',
+          {
+            type: 'person',
+            attribute: 'missingAttribute',
+            operator: 'EXCLUDES',
+            value: [19],
+          }
+        );
+
+        const rule = getRule(ruleConfig);
+        const matches = nodes.filter(rule);
+        expect(matches.length).toEqual(3);
+      });
+    });
+
+
     describe('type rules', () => {
       it('EXISTS', () => {
         const ruleConfig = generateRuleConfig('alter', { type: 'person', operator: 'EXISTS' });

--- a/predicate.js
+++ b/predicate.js
@@ -62,10 +62,12 @@ const predicate = operator =>
       case countOperators.COUNT_NOT:
         return !isEqual(value, other);
       case operators.INCLUDES: {
+        if (!value) { return false; } // ord/cat vars are initialised to null
         const difference = value.filter(x => !other.includes(x));
         return difference.length === 0;
       }
       case operators.EXCLUDES: {
+        if (!value) { return true; } // ord/cat vars are initialised to null
         const difference = value.filter(x => other.includes(x));
         return difference.length === 0;
       }


### PR DESCRIPTION
Network Canvas initializes node variables with default values. However, for ordinal and categorical variables, the initialisation value is `null`. This caused the existing logic tests to fail, and the app to crash.

This PR updates the predicate evaluation for INCLUDES and EXCLUDES to correctly handle a case where the node value is falsey, and adds tests that cover rules with missing variables or variables in the initialized state found in Network Canvas. 