### PR TITLE
Remove assert from query

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,11 +7,10 @@
         "node": true
     },
     "parserOptions": {
-        "ecmaVersion": 7,
+        "ecmaVersion": 2018,
         "ecmaFeatures": {
             "jsx": true,
             "spread": true,
-            "experimentalObjectRestSpread": true,
             "object-shorthand": ["error", "always"]
         },
         "sourceType": "module"

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -9,20 +9,10 @@ const getNodeGenerator = () => {
   };
 };
 
-const generateRuleConfig = (type, options, assert) => {
-  if (assert) {
-    return {
-      type,
-      options,
-      assert,
-    };
-  }
-
-  return {
-    type,
-    options,
-  };
-}
+const generateRuleConfig = (type, options) => ({
+  type,
+  options,
+});
 
 exports.getNodeGenerator = getNodeGenerator;
 exports.generateRuleConfig = generateRuleConfig;

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -35,9 +35,6 @@ describe('query', () => {
             operator: 'LESS_THAN',
             attribute: 'age',
             value: 20,
-          }, {
-            operator: 'COUNT_GREATER_THAN',
-            value: 1,
           }),
         ],
         join: 'OR',
@@ -57,9 +54,6 @@ describe('query', () => {
           operator: 'LESS_THAN',
           attribute: 'age',
           value: 20,
-        }, {
-          operator: 'COUNT_GREATER_THAN',
-          value: 3,
         }),
         generateRuleConfig('ego', {
           operator: 'EXACTLY',
@@ -86,9 +80,6 @@ describe('query', () => {
           operator: 'LESS_THAN',
           attribute: 'age',
           value: 20,
-        }, {
-          operator: 'COUNT_GREATER_THAN',
-          value: 3,
         }),
         generateRuleConfig('ego', {
           operator: 'EXACTLY',

--- a/filter.js
+++ b/filter.js
@@ -51,13 +51,16 @@ const trimEdges = (network) => {
 
 const filter = ({ rules = [], join } = {}) => {
   const ruleRunners = rules.map(getRule);
-  const joinType = join === 'AND' ? 'every' : 'some'; // use the built-in methods
+  // use the built-in array methods
+  const ruleIterator = join === 'AND' ?
+    Array.prototype.every :
+    Array.prototype.some;
 
   return (network) => {
     const edgeMap = buildEdgeLookup(network.edges);
 
     const nodes = network.nodes.filter(
-      node => ruleRunners[joinType](rule => rule(node, edgeMap)),
+      node => ruleIterator.call(ruleRunners, rule => rule(node, edgeMap)),
     );
 
     return trimEdges({

--- a/filter.js
+++ b/filter.js
@@ -52,9 +52,7 @@ const trimEdges = (network) => {
 const filter = ({ rules = [], join } = {}) => {
   const ruleRunners = rules.map(getRule);
   // use the built-in array methods
-  const ruleIterator = join === 'AND' ?
-    Array.prototype.every :
-    Array.prototype.some;
+  const ruleIterator = join === 'AND' ? Array.prototype.every : Array.prototype.some;
 
   return (network) => {
     const edgeMap = buildEdgeLookup(network.edges);

--- a/query.js
+++ b/query.js
@@ -1,9 +1,5 @@
 const buildEdgeLookup = require('./buildEdgeLookup');
 const getRule = require('./rules').default;
-const predicate = require('./predicate').default;
-
-const assertResult = (options, nodes) =>
-  predicate(options.operator)({ value: nodes.length, other: options.value });
 
 /**
  * Returns a method which can query the network.
@@ -43,9 +39,7 @@ const assertResult = (options, nodes) =>
 const query = ({ rules, join }) => {
   const ruleRunners = rules.map(getRule);
   // use the built-in array methods
-  const ruleIterator = join === 'AND' ?
-    Array.prototype.every :
-    Array.prototype.some;
+  const ruleIterator = join === 'AND' ? Array.prototype.every : Array.prototype.some;
 
   return (network) => {
     const edgeMap = buildEdgeLookup(network.edges);

--- a/rules.js
+++ b/rules.js
@@ -19,6 +19,8 @@ const edgeRule = ({ operator, type }) =>
     }
   };
 
+edgeRule.type = 'edge';
+
 /**
  * Creates an alter rule, which can be called with `rule(node)`
  *
@@ -63,6 +65,8 @@ const alterRule = ({ attribute, operator, type, value: other }) =>
     });
   };
 
+alterRule.type = 'alter';
+
 /**
  * Creates an ego rule, which can be called with `rule(node)`
  *
@@ -77,6 +81,8 @@ const egoRule = ({ attribute, operator, value: other }) =>
       value: node[nodeAttributesProperty][attribute],
       other,
     });
+
+egoRule.type = 'ego';
 
 /**
  * Creates a configured rule function based on the ruleConfig


### PR DESCRIPTION
The assert configuration has been dropped from our queries, but this method hadn't been updated to match the new schema.

Now rules are considered to have passed if any node matches the rule.

Partially resolves: https://github.com/codaco/Network-Canvas/issues/987