### PR TITLE
Fix/group rule types

### DIFF
--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -212,19 +212,19 @@ describe('query', () => {
     });
 
     describe('combining rule types', () => {
-      it('when ego and alter rules are joined by AND, they are first run in types of the same group before those results are then combined again with AND (pass)', () => {
+      it('when ego and alter/edge rules are joined by AND, they are first run in types of the same group before those results are then combined again with AND (pass)', () => {
         const successfulQuery = getQuery({
           join: 'AND',
-          rules: [trueEgoRule1, trueEgoRule2, trueAlterRule1],
+          rules: [trueEgoRule1, trueEgoRule2, trueAlterRule1, generateRuleConfig('edge', { type: 'friend', operator: 'EXISTS' })],
         });
 
         expect(successfulQuery(network)).toEqual(true);
       });
 
-      it('when ego and alter rules are joined by AND, they are first run in types of the same group before those results are then combined again with AND (fail)', () => {
+      it('when ego and alter/edge rules are joined by AND, they are first run in types of the same group before those results are then combined again with AND (fail)', () => {
         const successfulQuery = getQuery({
           join: 'AND',
-          rules: [trueEgoRule1, trueEgoRule2, falseAlterRule1],
+          rules: [trueEgoRule1, trueEgoRule2, falseAlterRule1, generateRuleConfig('edge', { type: 'friend', operator: 'EXISTS' })],
         });
 
         expect(successfulQuery(network)).toEqual(false);

--- a/query.js
+++ b/query.js
@@ -36,13 +36,20 @@ const getRule = require('./rules').default;
  * const result = query(network);
  */
 
+const typeMap = {
+  edge: 'alter_edge',
+  alter: 'alter_edge',
+  ego: 'ego',
+};
+
 const groupByType = (acc, rule) => {
   const { type } = rule;
-  const typeRules = (acc[type] || []).concat([rule]);
+  const mappedType = typeMap[type];
+  const typeRules = (acc[mappedType] || []).concat([rule]);
 
   return {
     ...acc,
-    [type]: typeRules,
+    [mappedType]: typeRules,
   };
 };
 
@@ -66,31 +73,12 @@ const getQuery = ({ rules, join }) => {
       }
 
       /*
-       * 'edge' type rules
-       * If any of the nodes match, this rule passes.
-       * Because this only checks for exists/not-exists, it could
-       * be made more efficient with a different map, but prefer
-       * parity with the filter function for now.
-       * As it stands alter rules and edge rules are considered
-       * separately, if groupByType combined them (node rules,
-       * can be passed the edgeMap, it will simply ignore it),
-       * then nodes would need to contain all properties AND/OR
-       * those same node be connected by edges.
-       */
-      if (type === 'edge') {
-        return network.nodes.some(
-          node =>
-            ruleIterator.call(typeRules, rule => rule(node, edgeMap)),
-        );
-      }
-
-      /*
-       * 'alter' type rule
+       * 'alter' and 'edge' type rules
        * If any of the nodes match, this rule passes.
        */
       return network.nodes.some(
         node =>
-          ruleIterator.call(typeRules, rule => rule(node)),
+          ruleIterator.call(typeRules, rule => rule(node, edgeMap)),
       );
     });
   };


### PR DESCRIPTION
This updates the query method to group rule types run against nodes (alter and edge rules), so that a single alter must match all relevant alter/edge rules (with specified join type), before being joined with ego rules.